### PR TITLE
Python 3 compatibility

### DIFF
--- a/hearstPatterns/hearstPatterns.py
+++ b/hearstPatterns/hearstPatterns.py
@@ -94,7 +94,7 @@ class HearstPatterns(object):
         for sentence in sentences:
             chunks = self.__np_chunker.parse(sentence) # parse the example sentence
             #for chunk in chunks:
-            #   print str(chunk)
+            #   print(str(chunk))
             all_chunks.append(self.prepare_chunks(chunks))
         return all_chunks
 
@@ -154,11 +154,11 @@ class HearstPatterns(object):
                     else:
                         general = nps[-1]
                         specifics = nps[:-1]
-                        print str(general)
-                        print str(nps)
+                        print(str(general))
+                        print(str(nps))
 
                     for i in range(len(specifics)):
-                        #print "%s, %s" % (specifics[i], general)
+                        #print("%s, %s" % (specifics[i], general))
                         hyponyms.append((self.clean_hyponym_term(specifics[i]), self.clean_hyponym_term(general)))
 
         return hyponyms

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,14 @@
+from setuptools import setup, find_packages
+
+setup(name = "hearstPatterns",
+      version = "0.1.2",
+      description = 'This is an implementation of Hearst patterns, for finding hyponyms, written in Python.',
+      url = 'https://github.com/mmichelsonIF/hearst_patterns_python',
+      author = 'mmichelsonIF',
+      author_email = 'mmichelson@inferlink.com',
+      license='Apache License 2.0',
+      packages = find_packages(),
+      install_requires=[
+          'nltk',
+      ],
+)


### PR DESCRIPTION
This pull request introduces Python 3 compatibility while still preserving compatibility with Python 2.

I've ran unittest with both Python 2 and 3:
```sh
koen@ubuntu:~/Git/hearst_patterns_python$ python --version
Python 2.7.14
koen@ubuntu:~/Git/hearst_patterns_python$ python -m unittest discover
NP_injuries
['NP_bruises', 'NP_lacerations', 'NP_injuries']
.
----------------------------------------------------------------------
Ran 1 test in 0.192s

OK
koen@ubuntu:~/Git/hearst_patterns_python$ python3 --version
Python 3.6.3
koen@ubuntu:~/Git/hearst_patterns_python$ python3 -m unittest discover
NP_injuries
['NP_bruises', 'NP_lacerations', 'NP_injuries']
.
----------------------------------------------------------------------
Ran 1 test in 0.108s

OK
```

