### PR TITLE
Fix error with string text replacement when chunk lemma is empty

### DIFF
--- a/hearstPatterns/hearstPatterns.py
+++ b/hearstPatterns/hearstPatterns.py
@@ -79,7 +79,8 @@ class HearstPatterns(object):
                     chunk_arr.append(token.lemma_)
                 chunk_lemma = " ".join(chunk_arr)
                 replacement_value = "NP_"+"_".join(chunk_arr)
-                sentence_text = sentence_text.replace(chunk_lemma, replacement_value)
+                if chunk_lemma:
+                    sentence_text = sentence_text.replace(chunk_lemma, replacement_value)
             chunks.append(sentence_text)
         return chunks
 


### PR DESCRIPTION
Would run into errors with noun chunks that were also in stopwords list

```
from hearstPatterns.hearstPatterns import HearstPatterns
hp = HearstPatterns(extended=True)
hp.chunk('In brief, I think that noun chunks composed of adj stopwords messes up this function.')

['NP_iNP_nNP_ NP_bNP_rNP_iNP_eNP_fNP_ NP_,NP_ NP_-NP_PNP_RNP_ONP_NNP_-NP_ NP_tNP_hNP_iNP_nNP_kNP_ NP_tNP_hNP_aNP_tNP_ NP_nNP_oNP_uNP_nNP_ NP_cNP_hNP_uNP_nNP_kNP_ NP_cNP_oNP_mNP_pNP_oNP_sNP_eNP_ NP_oNP_fNP_ NP_aNP_dNP_jNP_ NP_sNP_tNP_oNP_pNP_wNP_oNP_rNP_dNP_sNP_ NP_mNP_eNP_sNP_sNP_ NP_uNP_pNP_ NP_tNP_hNP_iNP_sNP_ NP_fNP_uNP_nNP_cNP_tNP_iNP_oNP_nNP_ NP_.NP_']
```