### PR TITLE
Fix bug with noun chunks lemmatizing to adjectives

### DIFF
--- a/hearstPatterns/hearstPatterns.py
+++ b/hearstPatterns/hearstPatterns.py
@@ -80,6 +80,8 @@ class HearstPatterns(object):
                         replace_arr.append(token.lemma_)
                     elif not token.lemma_.isalnum():
                         replace_arr.append(''.join(char for char in token.lemma_ if char.isalnum()))
+                if len(chunk_arr) == 0:
+                    chunk_arr.append(chunk[-1].lemma_)
                 chunk_lemma = ' '.join(chunk_arr)
                 replacement_value = 'NP_' + '_'.join(replace_arr)
                 if chunk_lemma:

--- a/hearstPatterns/hearstPatterns.py
+++ b/hearstPatterns/hearstPatterns.py
@@ -9,7 +9,7 @@ class HearstPatterns(object):
 
         # now define the Hearst patterns
         # format is <hearst-pattern>, <general-term>
-        # so, what this means is that if you apply the first pattern, the firsr Noun Phrase (NP)
+        # so, what this means is that if you apply the first pattern, the first Noun Phrase (NP)
         # is the general one, and the rest are specific NPs
         self.__hearst_patterns = [
             ('(NP_\\w+ (, )?such as (NP_\\w+ ? (, )?(and |or )?)+)', 'first'),
@@ -33,7 +33,7 @@ class HearstPatterns(object):
                 ('example of (NP_\\w+ (, )?be (NP_\\w+ ? (, )?(and |or )?)+)', 'first'),
                 ('((NP_\\w+ ?(, )?)+(and |or )?be example of NP_\\w+)', 'last'),
                 ('(NP_\\w+ (, )?for example (NP_\\w+ ? (, )?(and |or )?)+)', 'first'),
-                ('((NP_\\w+ ?(, )?)+(and |or )?wich be call NP_\\w+)', 'last'),
+                ('((NP_\\w+ ?(, )?)+(and |or )?which be call NP_\\w+)', 'last'),
                 ('((NP_\\w+ ?(, )?)+(and |or )?which be name NP_\\w+)', 'last'),
                 ('(NP_\\w+ (, )?mainly (NP_\\w+ ? (, )?(and |or )?)+)', 'first'),
                 ('(NP_\\w+ (, )?mostly (NP_\\w+ ? (, )?(and |or )?)+)', 'first'),


### PR DESCRIPTION
In the case where all words in a noun chunk lemmatize to words on the adjective stoplist (such as news, briefs, others, presents), the chunking code no longer inserts "NP_" between every character in the string, which then causes it to not slow to to an effective stop on the third Hearst pattern.