### PR TITLE
Add some new patterns and fix some bug

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -90,3 +90,4 @@ ENV/
 
 # Rope project settings
 .ropeproject
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ $ python
 python -m unittest discover
 ```
 
-====
+---
 # References:
 
 [1] Hearst, M. A. "Automatic acquisition of hyponyms from large text corpora." Proceedings of the 14th conference on Computational linguistics-Volume 2. Association for Computational Linguistics, 1992.

--- a/hearstPatterns/hearstPatterns.py
+++ b/hearstPatterns/hearstPatterns.py
@@ -85,8 +85,8 @@ class HearstPatterns(object):
                     'last'
                 ),
                 (
-                    'example of (NP_\\w+ (, )?be (NP_\\w+ ? \
-                    (, )?(and |or )?)+)',
+                    'example of (NP_\\w+ (, )?be (NP_\\w+ ? '
+                    '(, )?(and |or )?)+)',
                     'first'
                 ),
                 (
@@ -94,7 +94,8 @@ class HearstPatterns(object):
                     'last'
                 ),
                 (
-                    '(NP_\\w+ (, )?for example (NP_\\w+ ? (, )?(and |or )?)+)',
+                    '(NP_\\w+ (, )?for example (, )?'
+                    '(NP_\\w+ ?(, )?(and |or )?)+)',
                     'first'
                 ),
                 (
@@ -118,8 +119,8 @@ class HearstPatterns(object):
                     'first'
                 ),
                 (
-                    '(NP_\\w+ (, )?particularly (NP_\\w+ ? \
-                    (, )?(and |or )?)+)',
+                    '(NP_\\w+ (, )?particularly (NP_\\w+ ? '
+                    '(, )?(and |or )?)+)',
                     'first'
                 ),
                 (
@@ -127,8 +128,8 @@ class HearstPatterns(object):
                     'first'
                 ),
                 (
-                    '(NP_\\w+ (, )?in particular (NP_\\w+ ? \
-                    (, )?(and |or )?)+)',
+                    '(NP_\\w+ (, )?in particular (NP_\\w+ ? '
+                    '(, )?(and |or )?)+)',
                     'first'
                 ),
                 (
@@ -141,6 +142,11 @@ class HearstPatterns(object):
                 ),
                 (
                     '(NP_\\w+ (, )?e.g. (, )?(NP_\\w+ ? (, )?(and |or )?)+)',
+                    'first'
+                ),
+                (
+                    '(NP_\\w+ \\( (e.g.|i.e.) (, )?(NP_\\w+ ? (, )?(and |or )?)+'
+                    '(\\. )?\\))',
                     'first'
                 ),
                 (
@@ -168,13 +174,13 @@ class HearstPatterns(object):
                     'last'
                 ),
                 (
-                    '(NP_\\w+ (, )?which be similar to (NP_\\w+ ? \
-                    (, )?(and |or )?)+)',
+                    '(NP_\\w+ (, )?which be similar to (NP_\\w+ ? '
+                    '(, )?(and |or )?)+)',
                     'first'
                 ),
                 (
-                    '(NP_\\w+ (, )?example of this be (NP_\\w+ ? \
-                    (, )?(and |or )?)+)',
+                    '(NP_\\w+ (, )?example of this be (NP_\\w+ ? '
+                    '(, )?(and |or )?)+)',
                     'first'
                 ),
                 (
@@ -198,8 +204,8 @@ class HearstPatterns(object):
                     'first'
                 ),
                 (
-                    '(NP_\\w+ (, )?among -PRON- (NP_\\w+ ? \
-                    (, )?(and |or )?)+)',
+                    '(NP_\\w+ (, )?among -PRON- (NP_\\w+ ? '
+                    '(, )?(and |or )?)+)',
                     'first'
                 ),
                 (
@@ -207,13 +213,18 @@ class HearstPatterns(object):
                     'last'
                 ),
                 (
-                    '(NP_\\w+ (, )? (NP_\\w+ ? (, )?(and |or )?)+ \
-                    for instance)',
+                    '(NP_\\w+ (, )? (NP_\\w+ ? (, )?(and |or )?)+ '
+                    'for instance)',
                     'first'
                 ),
                 (
                     '((NP_\\w+ ?(, )?)+(and|or)? sort of NP_\\w+)',
                     'last'
+                ),
+                (
+                    '(NP_\\w+ (, )?which may include (NP_\\w+ '
+                    '?(, )?(and |or )?)+)',
+                    'first'
                 )
             ])
 

--- a/hearstPatterns/hearstPatterns.py
+++ b/hearstPatterns/hearstPatterns.py
@@ -2,87 +2,257 @@ import re
 import string
 import spacy
 
+
 class HearstPatterns(object):
 
-    def __init__(self, extended = False):
-        self.__adj_stopwords = ['able', 'available', 'brief', 'certain', 'different', 'due', 'enough', 'especially','few', 'fifth', 'former', 'his', 'howbeit', 'immediate', 'important', 'inc', 'its', 'last', 'latter', 'least', 'less', 'likely', 'little', 'many', 'ml', 'more', 'most', 'much', 'my', 'necessary', 'new', 'next', 'non', 'old', 'other', 'our', 'ours', 'own', 'particular', 'past', 'possible', 'present', 'proud', 'recent', 'same', 'several', 'significant', 'similar', 'such', 'sup', 'sure']
+    def __init__(self, extended=False):
+
+        self.__adj_stopwords = [
+            'able', 'available', 'brief', 'certain',
+            'different', 'due', 'enough', 'especially', 'few', 'fifth',
+            'former', 'his', 'howbeit', 'immediate', 'important', 'inc',
+            'its', 'last', 'latter', 'least', 'less', 'likely', 'little',
+            'many', 'ml', 'more', 'most', 'much', 'my', 'necessary',
+            'new', 'next', 'non', 'old', 'other', 'our', 'ours', 'own',
+            'particular', 'past', 'possible', 'present', 'proud', 'recent',
+            'same', 'several', 'significant', 'similar', 'such', 'sup', 'sure'
+        ]
 
         # now define the Hearst patterns
         # format is <hearst-pattern>, <general-term>
-        # so, what this means is that if you apply the first pattern, the first Noun Phrase (NP)
+        # so, what this means is that if you apply the first pattern,
+        # the first Noun Phrase (NP)
         # is the general one, and the rest are specific NPs
         self.__hearst_patterns = [
-            ('(NP_\\w+ (, )?such as (NP_\\w+ ? (, )?(and |or )?)+)', 'first'),
-            ('(such NP_\\w+ (, )?as (NP_\\w+ ?(, )?(and |or )?)+)', 'first'),
-            ('((NP_\\w+ ?(, )?)+(and |or )?other NP_\\w+)', 'last'),
-            ('(NP_\\w+ (, )?include (NP_\\w+ ?(, )?(and |or )?)+)', 'first'),
-            ('(NP_\\w+ (, )?especially (NP_\\w+ ?(, )?(and |or )?)+)', 'first'),
+            (
+                '(NP_\\w+ (, )?such as (NP_\\w+ ?(, )?(and |or )?)+)',
+                'first'
+            ),
+            (
+                '(such NP_\\w+ (, )?as (NP_\\w+ ?(, )?(and |or )?)+)',
+                'first'
+            ),
+            (
+                '((NP_\\w+ ?(, )?)+(and |or )?other NP_\\w+)',
+                'last'
+            ),
+            (
+                '(NP_\\w+ (, )?include (NP_\\w+ ?(, )?(and |or )?)+)',
+                'first'
+            ),
+            (
+                '(NP_\\w+ (, )?especially (NP_\\w+ ?(, )?(and |or )?)+)',
+                'first'
+            ),
         ]
 
         if extended:
             self.__hearst_patterns.extend([
-                ('((NP_\\w+ ?(, )?)+(and |or )?any other NP_\\w+)', 'last'),
-                ('((NP_\\w+ ?(, )?)+(and |or )?some other NP_\\w+)', 'last'),
-                ('((NP_\\w+ ?(, )?)+(and |or )?be a NP_\\w+)', 'last'),
-                ('(NP_\\w+ (, )?like (NP_\\w+ ? (, )?(and |or )?)+)', 'first'),
-                ('such (NP_\\w+ (, )?as (NP_\\w+ ? (, )?(and |or )?)+)', 'first'),
-                ('((NP_\\w+ ?(, )?)+(and |or )?like other NP_\\w+)', 'last'),
-                ('((NP_\\w+ ?(, )?)+(and |or )?one of the NP_\\w+)', 'last'),
-                ('((NP_\\w+ ?(, )?)+(and |or )?one of these NP_\\w+)', 'last'),
-                ('((NP_\\w+ ?(, )?)+(and |or )?one of those NP_\\w+)', 'last'),
-                ('example of (NP_\\w+ (, )?be (NP_\\w+ ? (, )?(and |or )?)+)', 'first'),
-                ('((NP_\\w+ ?(, )?)+(and |or )?be example of NP_\\w+)', 'last'),
-                ('(NP_\\w+ (, )?for example (NP_\\w+ ? (, )?(and |or )?)+)', 'first'),
-                ('((NP_\\w+ ?(, )?)+(and |or )?which be call NP_\\w+)', 'last'),
-                ('((NP_\\w+ ?(, )?)+(and |or )?which be name NP_\\w+)', 'last'),
-                ('(NP_\\w+ (, )?mainly (NP_\\w+ ? (, )?(and |or )?)+)', 'first'),
-                ('(NP_\\w+ (, )?mostly (NP_\\w+ ? (, )?(and |or )?)+)', 'first'),
-                ('(NP_\\w+ (, )?notably (NP_\\w+ ? (, )?(and |or )?)+)', 'first'),
-                ('(NP_\\w+ (, )?particularly (NP_\\w+ ? (, )?(and |or )?)+)', 'first'),
-                ('(NP_\\w+ (, )?principally (NP_\\w+ ? (, )?(and |or )?)+)', 'first'),
-                ('(NP_\\w+ (, )?in particular (NP_\\w+ ? (, )?(and |or )?)+)', 'first'),
-                ('(NP_\\w+ (, )?except (NP_\\w+ ? (, )?(and |or )?)+)', 'first'),
-                ('(NP_\\w+ (, )?other than (NP_\\w+ ? (, )?(and |or )?)+)', 'first'),
-                ('(NP_\\w+ (, )?e.g. (NP_\\w+ ? (, )?(and |or )?)+)', 'first'),
-                ('(NP_\\w+ (, )?i.e. (NP_\\w+ ? (, )?(and |or )?)+)', 'first'),
-                ('((NP_\\w+ ?(, )?)+(and|or)? a kind of NP_\\w+)', 'last'),
-                ('((NP_\\w+ ?(, )?)+(and|or)? kind of NP_\\w+)', 'last'),
-                ('((NP_\\w+ ?(, )?)+(and|or)? form of NP_\\w+)', 'last'),
-                ('((NP_\\w+ ?(, )?)+(and |or )?which look like NP_\\w+)', 'last'),
-                ('((NP_\\w+ ?(, )?)+(and |or )?which sound like NP_\\w+)', 'last'),
-                ('(NP_\\w+ (, )?which be similar to (NP_\\w+ ? (, )?(and |or )?)+)', 'first'),
-                ('(NP_\\w+ (, )?example of this be (NP_\\w+ ? (, )?(and |or )?)+)', 'first'),
-                ('(NP_\\w+ (, )?type (NP_\\w+ ? (, )?(and |or )?)+)', 'first'),
-                ('((NP_\\w+ ?(, )?)+(and |or )? NP_\\w+ type)', 'last'),
-                ('(NP_\\w+ (, )?whether (NP_\\w+ ? (, )?(and |or )?)+)', 'first'),
-                ('(compare (NP_\\w+ ?(, )?)+(and |or )?with NP_\\w+)', 'last'),
-                ('(NP_\\w+ (, )?compare to (NP_\\w+ ? (, )?(and |or )?)+)', 'first'),
-                ('(NP_\\w+ (, )?among -PRON- (NP_\\w+ ? (, )?(and |or )?)+)', 'first'),
-                ('((NP_\\w+ ?(, )?)+(and |or )?as NP_\\w+)', 'last'),
-                ('(NP_\\w+ (, )? (NP_\\w+ ? (, )?(and |or )?)+ for instance)', 'first'),
-                ('((NP_\\w+ ?(, )?)+(and|or)? sort of NP_\\w+)', 'last')
+                (
+                    '((NP_\\w+ ?(, )?)+(and |or )?any other NP_\\w+)',
+                    'last'
+                ),
+                (
+                    '((NP_\\w+ ?(, )?)+(and |or )?some other NP_\\w+)',
+                    'last'
+                ),
+                (
+                    '((NP_\\w+ ?(, )?)+(and |or )?be a NP_\\w+)',
+                    'last'
+                ),
+                (
+                    '(NP_\\w+ (, )?like (NP_\\w+ ? (, )?(and |or )?)+)',
+                    'first'
+                ),
+                (
+                    'such (NP_\\w+ (, )?as (NP_\\w+ ? (, )?(and |or )?)+)',
+                    'first'
+                ),
+                (
+                    '((NP_\\w+ ?(, )?)+(and |or )?like other NP_\\w+)',
+                    'last'
+                ),
+                (
+                    '((NP_\\w+ ?(, )?)+(and |or )?one of the NP_\\w+)',
+                    'last'
+                ),
+                (
+                    '((NP_\\w+ ?(, )?)+(and |or )?one of these NP_\\w+)',
+                    'last'
+                ),
+                (
+                    '((NP_\\w+ ?(, )?)+(and |or )?one of those NP_\\w+)',
+                    'last'
+                ),
+                (
+                    'example of (NP_\\w+ (, )?be (NP_\\w+ ? \
+                    (, )?(and |or )?)+)',
+                    'first'
+                ),
+                (
+                    '((NP_\\w+ ?(, )?)+(and |or )?be example of NP_\\w+)',
+                    'last'
+                ),
+                (
+                    '(NP_\\w+ (, )?for example (NP_\\w+ ? (, )?(and |or )?)+)',
+                    'first'
+                ),
+                (
+                    '((NP_\\w+ ?(, )?)+(and |or )?which be call NP_\\w+)',
+                    'last'
+                ),
+                (
+                    '((NP_\\w+ ?(, )?)+(and |or )?which be name NP_\\w+)',
+                    'last'
+                ),
+                (
+                    '(NP_\\w+ (, )?mainly (NP_\\w+ ? (, )?(and |or )?)+)',
+                    'first'
+                ),
+                (
+                    '(NP_\\w+ (, )?mostly (NP_\\w+ ? (, )?(and |or )?)+)',
+                    'first'
+                ),
+                (
+                    '(NP_\\w+ (, )?notably (NP_\\w+ ? (, )?(and |or )?)+)',
+                    'first'
+                ),
+                (
+                    '(NP_\\w+ (, )?particularly (NP_\\w+ ? \
+                    (, )?(and |or )?)+)',
+                    'first'
+                ),
+                (
+                    '(NP_\\w+ (, )?principally (NP_\\w+ ? (, )?(and |or )?)+)',
+                    'first'
+                ),
+                (
+                    '(NP_\\w+ (, )?in particular (NP_\\w+ ? \
+                    (, )?(and |or )?)+)',
+                    'first'
+                ),
+                (
+                    '(NP_\\w+ (, )?except (NP_\\w+ ? (, )?(and |or )?)+)',
+                    'first'
+                ),
+                (
+                    '(NP_\\w+ (, )?other than (NP_\\w+ ? (, )?(and |or )?)+)',
+                    'first'
+                ),
+                (
+                    '(NP_\\w+ (, )?e.g. (, )?(NP_\\w+ ? (, )?(and |or )?)+)',
+                    'first'
+                ),
+                (
+                    '(NP_\\w+ (, )?i.e. (, )?(NP_\\w+ ? (, )?(and |or )?)+)',
+                    'first'
+                ),
+                (
+                    '((NP_\\w+ ?(, )?)+(and|or)? a kind of NP_\\w+)',
+                    'last'
+                ),
+                (
+                    '((NP_\\w+ ?(, )?)+(and|or)? kind of NP_\\w+)',
+                    'last'
+                ),
+                (
+                    '((NP_\\w+ ?(, )?)+(and|or)? form of NP_\\w+)',
+                    'last'
+                ),
+                (
+                    '((NP_\\w+ ?(, )?)+(and |or )?which look like NP_\\w+)',
+                    'last'
+                ),
+                (
+                    '((NP_\\w+ ?(, )?)+(and |or )?which sound like NP_\\w+)',
+                    'last'
+                ),
+                (
+                    '(NP_\\w+ (, )?which be similar to (NP_\\w+ ? \
+                    (, )?(and |or )?)+)',
+                    'first'
+                ),
+                (
+                    '(NP_\\w+ (, )?example of this be (NP_\\w+ ? \
+                    (, )?(and |or )?)+)',
+                    'first'
+                ),
+                (
+                    '(NP_\\w+ (, )?type (NP_\\w+ ? (, )?(and |or )?)+)',
+                    'first'
+                ),
+                (
+                    '((NP_\\w+ ?(, )?)+(and |or )? NP_\\w+ type)',
+                    'last'
+                ),
+                (
+                    '(NP_\\w+ (, )?whether (NP_\\w+ ? (, )?(and |or )?)+)',
+                    'first'
+                ),
+                (
+                    '(compare (NP_\\w+ ?(, )?)+(and |or )?with NP_\\w+)',
+                    'last'
+                ),
+                (
+                    '(NP_\\w+ (, )?compare to (NP_\\w+ ? (, )?(and |or )?)+)',
+                    'first'
+                ),
+                (
+                    '(NP_\\w+ (, )?among -PRON- (NP_\\w+ ? \
+                    (, )?(and |or )?)+)',
+                    'first'
+                ),
+                (
+                    '((NP_\\w+ ?(, )?)+(and |or )?as NP_\\w+)',
+                    'last'
+                ),
+                (
+                    '(NP_\\w+ (, )? (NP_\\w+ ? (, )?(and |or )?)+ \
+                    for instance)',
+                    'first'
+                ),
+                (
+                    '((NP_\\w+ ?(, )?)+(and|or)? sort of NP_\\w+)',
+                    'last'
+                )
             ])
 
         self.__spacy_nlp = spacy.load('en')
-        
+
     def chunk(self, rawtext):
         doc = self.__spacy_nlp(rawtext)
         chunks = []
         for sentence in doc.sents:
             sentence_text = sentence.lemma_
             for chunk in sentence.noun_chunks:
+                if chunk.lemma_.lower() == "example":
+                    start = chunk.start
+                    pre_token = sentence[start - 1].lemma_.lower()
+                    post_token = sentence[start + 1].lemma_.lower()
+                    if start > 0 and\
+                            (pre_token == "for" or post_token == "of"):
+                        continue
+                if chunk.lemma_.lower() == "type":
+                    continue
                 chunk_arr = []
                 replace_arr = []
+                # print("chunk:", chunk)
                 for token in chunk:
+                    if token.lemma_ in self.__adj_stopwords + ["i.e.", "e.g."]:
+                        continue
                     chunk_arr.append(token.lemma_)
-                    # Remove punctuation and stopword adjectives (generally quantifiers of plurals)
-                    if token.lemma_.isalnum() and token.lemma_ not in self.__adj_stopwords:
+                    # Remove punctuation and stopword adjectives
+                    # (generally quantifiers of plurals)
+                    if token.lemma_.isalnum():
                         replace_arr.append(token.lemma_)
-                    elif not token.lemma_.isalnum():
-                        replace_arr.append(''.join(char for char in token.lemma_ if char.isalnum()))
+                    else:
+                        replace_arr.append(''.join(
+                            char for char in token.lemma_ if char.isalnum()
+                        ))
                 if len(chunk_arr) == 0:
                     chunk_arr.append(chunk[-1].lemma_)
                 chunk_lemma = ' '.join(chunk_arr)
+                # print(chunk_lemma)
                 replacement_value = 'NP_' + '_'.join(replace_arr)
                 if chunk_lemma:
                     sentence_text = re.sub(r'\b%s\b' % re.escape(chunk_lemma),
@@ -93,7 +263,8 @@ class HearstPatterns(object):
 
     """
         This is the main entry point for this code.
-        It takes as input the rawtext to process and returns a list of tuples (specific-term, general-term)
+        It takes as input the rawtext to process and returns a list
+        of tuples (specific-term, general-term)
         where each tuple represents a hypernym pair.
 
     """
@@ -103,7 +274,8 @@ class HearstPatterns(object):
         np_tagged_sentences = self.chunk(rawtext)
 
         for sentence in np_tagged_sentences:
-            # two or more NPs next to each other should be merged into a single NP, it's a chunk error
+            # two or more NPs next to each other should be merged
+            # into a single NP, it's a chunk error
 
             for (hearst_pattern, parser) in self.__hearst_patterns:
                 matches = re.search(hearst_pattern, sentence)
@@ -118,17 +290,18 @@ class HearstPatterns(object):
                     else:
                         general = nps[-1]
                         specifics = nps[:-1]
-                        print(str(general))
-                        print(str(nps))
 
                     for i in range(len(specifics)):
-                        #print("%s, %s" % (specifics[i], general))
-                        hyponyms.append((self.clean_hyponym_term(specifics[i]), self.clean_hyponym_term(general)))
+                        pair = (
+                            self.clean_hyponym_term(specifics[i]),
+                            self.clean_hyponym_term(general)
+                        )
+                        # reduce duplicates
+                        if pair not in hyponyms:
+                            hyponyms.append(pair)
 
         return hyponyms
 
-
     def clean_hyponym_term(self, term):
         # good point to do the stemming or lemmatization
-        return term.replace("NP_","").replace("_", " ")
-
+        return term.replace("NP_", "").replace("_", " ")

--- a/hearstPatterns/test_hearstPatterns.py
+++ b/hearstPatterns/test_hearstPatterns.py
@@ -1,0 +1,68 @@
+import unittest
+from hearstPatterns import HearstPatterns
+
+
+class TestHearstPatterns(unittest.TestCase):
+
+    def test_hyponym_finder(self):
+        h = HearstPatterns(extended=True)
+
+        # H1
+        hyps1 = h.find_hyponyms("Forty-four percent of patients with uveitis had one or more identifiable signs or symptoms, such as red eye, ocular pain, visual acuity, or photophobia, in order of decreasing frequency.")
+
+        self.assertEqual(tuple(map(str.lower, hyps1[0])), ("red eye", "symptom"))
+        self.assertEqual(tuple(map(str.lower, hyps1[1])), ("ocular pain", "symptom"))
+        self.assertEqual(tuple(map(str.lower, hyps1[2])), ("visual acuity", "symptom"))
+        self.assertEqual(tuple(map(str.lower, hyps1[3])), ("photophobia", "symptom"))
+
+        # H2
+        hyps2 = h.find_hyponyms("There are works by such authors as Herrick, Goldsmith, and Shakespeare.")
+        self.assertEqual(tuple(map(str.lower, hyps2[0])), ("herrick", "author"))
+        self.assertEqual(tuple(map(str.lower, hyps2[1])), ("goldsmith", "author"))
+        self.assertEqual(tuple(map(str.lower, hyps2[2])), ("shakespeare", "author"))
+
+        # H3
+        hyps3 = h.find_hyponyms("There were bruises, lacerations, or other injuries were not prevalent.")
+        self.assertEqual(tuple(map(str.lower, hyps3[0])), ("bruise", "injury"))
+        self.assertEqual(tuple(map(str.lower, hyps3[1])), ("laceration", "injury"))
+
+        # H4
+        hyps4 = h.find_hyponyms("common law countries, including Canada, Australia, and England enjoy toast.")
+        self.assertEqual(tuple(map(str.lower, hyps4[0])), ("canada", "common law country"))
+        self.assertEqual(tuple(map(str.lower, hyps4[1])), ("australia", "common law country"))
+        self.assertEqual(tuple(map(str.lower, hyps4[2])), ("england", "common law country"))
+
+        # H5
+        hyps5 = h.find_hyponyms("Many countries, especially France, England and Spain also enjoy toast.")
+        self.assertEqual(tuple(map(str.lower, hyps5[0])), ("france", "country"))
+        self.assertEqual(tuple(map(str.lower, hyps5[1])), ("england", "country"))
+        self.assertEqual(tuple(map(str.lower, hyps5[2])), ("spain", "country"))
+
+        # H2
+        hyps6 = h.find_hyponyms("There are such benefits as postharvest losses reduction, food increase and soil fertility improvement.")
+        self.assertEqual(tuple(map(str.lower, hyps6[0])), ("postharvest loss reduction", "benefit"))
+        self.assertEqual(tuple(map(str.lower, hyps6[1])), ("food increase", "benefit"))
+        self.assertEqual(tuple(map(str.lower, hyps6[2])), ("soil fertility improvement", "benefit"))
+
+        # H'1
+        hyps7 = h.find_hyponyms("Fruits, i.e. , apples, bananas, oranges and peaches.")
+        self.assertEqual(tuple(map(str.lower, hyps7[0])), ("apple", "fruit"))
+        self.assertEqual(tuple(map(str.lower, hyps7[1])), ("banana", "fruit"))
+        self.assertEqual(tuple(map(str.lower, hyps7[2])), ("orange", "fruit"))
+        self.assertEqual(tuple(map(str.lower, hyps7[3])), ("peach", "fruit"))
+
+        hyps7 = h.find_hyponyms("Fruits, e.g. apples, bananas, oranges and peaches.")
+        self.assertEqual(tuple(map(str.lower, hyps7[0])), ("apple", "fruit"))
+        self.assertEqual(tuple(map(str.lower, hyps7[1])), ("banana", "fruit"))
+        self.assertEqual(tuple(map(str.lower, hyps7[2])), ("orange", "fruit"))
+        self.assertEqual(tuple(map(str.lower, hyps7[3])), ("peach", "fruit"))
+
+        # H'3
+        hyps8 = h.find_hyponyms("Fruits, for example, apples, bananas, oranges and peaches.")
+        self.assertEqual(tuple(map(str.lower, hyps7[0])), ("apple", "fruit"))
+        self.assertEqual(tuple(map(str.lower, hyps7[1])), ("banana", "fruit"))
+        self.assertEqual(tuple(map(str.lower, hyps7[2])), ("orange", "fruit"))
+        self.assertEqual(tuple(map(str.lower, hyps7[3])), ("peach", "fruit"))
+
+if __name__ == '__main__':
+    unittest.main()

--- a/hearstPatterns/test_hearstPatterns.py
+++ b/hearstPatterns/test_hearstPatterns.py
@@ -1,5 +1,5 @@
 import unittest
-from hearstPatterns import HearstPatterns
+from hearstPatterns.hearstPatterns import HearstPatterns
 
 
 class TestHearstPatterns(unittest.TestCase):
@@ -57,12 +57,34 @@ class TestHearstPatterns(unittest.TestCase):
         self.assertEqual(tuple(map(str.lower, hyps7[2])), ("orange", "fruit"))
         self.assertEqual(tuple(map(str.lower, hyps7[3])), ("peach", "fruit"))
 
+        # H'2
+
+        hyps10 = h.find_hyponyms("Fruits (e.g. apples, bananas, oranges and peaches.)")
+        self.assertEqual(tuple(map(str.lower, hyps10[0])), ("apple", "fruit"))
+        self.assertEqual(tuple(map(str.lower, hyps10[1])), ("banana", "fruit"))
+        self.assertEqual(tuple(map(str.lower, hyps10[2])), ("orange", "fruit"))
+        self.assertEqual(tuple(map(str.lower, hyps10[3])), ("peach", "fruit"))
+
+        hyps10 = h.find_hyponyms("Fruits (i.e. apples, bananas, oranges and peaches.)")
+        self.assertEqual(tuple(map(str.lower, hyps10[0])), ("apple", "fruit"))
+        self.assertEqual(tuple(map(str.lower, hyps10[1])), ("banana", "fruit"))
+        self.assertEqual(tuple(map(str.lower, hyps10[2])), ("orange", "fruit"))
+        self.assertEqual(tuple(map(str.lower, hyps10[3])), ("peach", "fruit"))
+
         # H'3
-        hyps8 = h.find_hyponyms("Fruits, for example, apples, bananas, oranges and peaches.")
-        self.assertEqual(tuple(map(str.lower, hyps7[0])), ("apple", "fruit"))
-        self.assertEqual(tuple(map(str.lower, hyps7[1])), ("banana", "fruit"))
-        self.assertEqual(tuple(map(str.lower, hyps7[2])), ("orange", "fruit"))
-        self.assertEqual(tuple(map(str.lower, hyps7[3])), ("peach", "fruit"))
+        hyps8 = h.find_hyponyms("Fruits, for example apples, bananas, oranges and peaches.")
+        self.assertEqual(tuple(map(str.lower, hyps8[0])), ("apple", "fruit"))
+        self.assertEqual(tuple(map(str.lower, hyps8[1])), ("banana", "fruit"))
+        self.assertEqual(tuple(map(str.lower, hyps8[2])), ("orange", "fruit"))
+        self.assertEqual(tuple(map(str.lower, hyps8[3])), ("peach", "fruit"))
+
+        # H'4
+        hyps9 = h.find_hyponyms("Fruits, which may include apples, bananas, oranges and peaches.")
+        self.assertEqual(tuple(map(str.lower, hyps9[0])), ("apple", "fruit"))
+        self.assertEqual(tuple(map(str.lower, hyps9[1])), ("banana", "fruit"))
+        self.assertEqual(tuple(map(str.lower, hyps9[2])), ("orange", "fruit"))
+        self.assertEqual(tuple(map(str.lower, hyps9[3])), ("peach", "fruit"))
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
# New patterns

- X, which may include Y1, Y2, . . .Yn
- X, e.g.|i.e. Y1, Y2, . . .Yn 
- X (e.g.|i.e. Y1, Y2, . . .Yn)

# Bug

- Remove print statements for debug
- Add statements to reduce duplicates
- Add check statements in case that the noun phrases fixed in some patterns like `for example` would lead to wrong results